### PR TITLE
Update graph.dart to make deep list work

### DIFF
--- a/lib/src/graph.dart
+++ b/lib/src/graph.dart
@@ -756,7 +756,9 @@ class Graph {
 
         // TODO try to parse to int/float etc
         Map objMap = {
-          objName: subValues.length == 1 ? subValues[0] : subValues
+          item(objName): subValues.length == 1
+              ? item(subValues[0])
+              : subValues.map((e) => item(e)).toSet()
         };
         values.add(objMap);
       } else {


### PR DESCRIPTION
Update `parseObjectValues` to parse deeper lists 

Peviously it gets serialized string:

`rdfs:range {URIRef(http://www.w3.org/1999/02/22-rdf-syntax-ns#type): {URIRef(http://www.w3.org/2000/01/rdf-schema#Datatype)}, URIRef(http://www.w3.org/2002/07/owl#onDatatype): {URIRef(http://www.w3.org/2001/XMLSchema#decimal)}, URIRef(http://www.w3.org/2002/07/owl#withRestrictions): {{{xsd:minExclusive: 0.0}}}} .`

After update, it gets the serialized string:
`rdfs:range {URIRef(http://www.w3.org/1999/02/22-rdf-syntax-ns#type): {URIRef(http://www.w3.org/2000/01/rdf-schema#Datatype)}, URIRef(http://www.w3.org/2002/07/owl#onDatatype): {URIRef(http://www.w3.org/2001/XMLSchema#decimal)}, URIRef(http://www.w3.org/2002/07/owl#withRestrictions): {{{URIRef(http://www.w3.org/2001/XMLSchema#minExclusive): Literal(0.0, datatype: URIRef(http://www.w3.org/2001/XMLSchema#float))}}}} .`